### PR TITLE
Fixes build error

### DIFF
--- a/StartAudioContext.js
+++ b/StartAudioContext.js
@@ -187,4 +187,4 @@
 	}
 
 	return StartAudioContext
-}))
+}));


### PR DESCRIPTION
The missing semicolon caused the error `Uncaught TypeError: (intermediate value)(…) is not a function` in a minified build.